### PR TITLE
Append the shrug to the user supplied text

### DIFF
--- a/shrug.py
+++ b/shrug.py
@@ -4,10 +4,13 @@
 #
 import weechat
 
+SHRUG = u"\u00af\_(\u30c4)_/\u00af"
+
 weechat.register("shrug", "krinkle", "0.0.1", "Apache-2.0", "Shrug", "", "")
 
 def shrug(data, buffer, args):
-    weechat.command(buffer, u"\u00af\_(\u30c4)_/\u00af".encode('utf-8'))
+    text = (' '.join([args, SHRUG])) if args else SHRUG
+    weechat.command(buffer, text.encode('utf-8'))
     return weechat.WEECHAT_RC_OK
 
 hook = weechat.hook_command("shrug", "Shrug", "", "", "", "shrug", weechat.current_buffer())


### PR DESCRIPTION
This gives the same behaviour as the Slack shrug slash command:

```
/shrug
=> ¯\_(ツ)_/¯

/shrug some text I'd like to post as well
=> some text I'd like to post as well ¯\_(ツ)_/¯
```